### PR TITLE
Implement feature to reject autopopulated works but save their doi

### DIFF
--- a/app/controllers/hyrax/autopopulation/dashboard/work_fetchers_controller.rb
+++ b/app/controllers/hyrax/autopopulation/dashboard/work_fetchers_controller.rb
@@ -88,6 +88,14 @@ module Hyrax
           redirect_to hyrax_autopopulation.work_fetchers_path(anchor: "approved-import")
         end
 
+        def reject_multiple
+          args = pass_arguments_by_storage_type([current_user, params["work_ids"]])
+          config_object.rejection_job.constantize.perform_later(*args)
+
+          flash[:notice] = I18n.t("hyrax.autopopulation.persistence.reject")
+          redirect_to hyrax_autopopulation.work_fetchers_path(anchor: "previously-added-id")
+        end
+
         private
 
           def autopopulation_settings_params
@@ -127,8 +135,10 @@ module Hyrax
 
           def fetch_saved_ids
             args = pass_arguments_by_storage_type([])
-            @saved_orcids = config_object.query_class.constantize.new(*args).orcid_from_db
-            @saved_doi = config_object.query_class.constantize.new(*args).fetch_doi_list
+            klass = config_object.query_class.constantize.new(*args)
+            @saved_orcids = klass.orcid_from_db
+            @saved_doi = klass.fetch_doi_list
+            @rejected_doi = klass.fetch_rejected_doi
           end
       end
     end

--- a/app/jobs/hyrax/autopopulation/rejection_job.rb
+++ b/app/jobs/hyrax/autopopulation/rejection_job.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module Autopopulation
+    # calls Hyrax::Autopopulation::ApprovalJob
+    # params [aproval_type] eg multiple or all
+    # params :user
+    # params :account used by hyku apps
+    # params :work_ids when approval_type is multiple ie submitted from check_box ticked
+    class RejectionJob < ApplicationJob
+      def perform(user, work_ids = nil, account = nil)
+        config = Rails.application.config.hyrax_autopopulation
+
+        works = config.query_class.constantize.new(account).fetch_by_ids(work_ids)
+        klass = config.persistence_class.constantize.new(works: works, account: account)
+        klass.save_rejected_ids.delete_rejected_works
+
+        autopopulation_complete_notification(user)
+      end
+
+      private
+
+        def autopopulation_complete_notification(user)
+          user.send_message(user, I18n.t("hyrax.autopopulation.notification.rejection_subject"), I18n.t("hyrax.autopopulation.notification.rejection_body"))
+        end
+    end
+  end
+end

--- a/app/services/hyrax/autopopulation/fetch_and_save_work_metadata.rb
+++ b/app/services/hyrax/autopopulation/fetch_and_save_work_metadata.rb
@@ -15,7 +15,7 @@ module Hyrax
 
       def save
         doi_list&.compact&.each do |doi|
-          next if doi.nil? || check_for_work_doi(doi)&.positive?
+          next if doi.nil? || check_for_work_doi(doi)&.positive? || rejected_dois.include?(doi)
 
           fetch_and_create_work_with_doi(doi)
         end
@@ -48,6 +48,10 @@ module Hyrax
 
         def fetch_crossref_work_data(doi)
           config.crossref_bolognese_client.constantize.new(input: doi)&.build_work_actor_attributes
+        end
+
+        def rejected_dois
+          config.query_class.constantize.new(account).fetch_rejected_doi
         end
 
         def autopopulation_complete_notification

--- a/app/services/hyrax/autopopulation/orcid_client.rb
+++ b/app/services/hyrax/autopopulation/orcid_client.rb
@@ -61,7 +61,7 @@ module Hyrax
           token = if config.active_record?
                     account.settings&.dig("hyrax_orcid_settings", "access_token")
                   else
-                    config.redis_storage_class.constantize.new.get_hash("hyrax_orcid_settings", "access_token")
+                    config.redis_storage_class.constantize.new.get_hash("hyrax_orcid_settings")&.dig("access_token")
                   end
 
           { "authorization" => "Bearer #{token}", "Content-Type" => "application/json" }

--- a/app/services/hyrax/autopopulation/record_fetcher.rb
+++ b/app/services/hyrax/autopopulation/record_fetcher.rb
@@ -11,20 +11,16 @@ module Hyrax
       end
 
       def orcid_from_db
-        if config.active_record? && Object.const_defined?(:Account)
-          account.settings.dig("orcid_list")
-        else
-          config.redis_storage_class.constantize.new.get_array("orcid_list")
-        end
+        fetch_by("orcid_list")&.presence || []
       end
 
       # Calls out to ::Hyrax::Autopopulation::RedisStorage.new.get_array("doi_list")
       def fetch_doi_list
-        if config.active_record? && Object.const_defined?(:Account)
-          account.settings.dig("doi_list")
-        else
-          config.redis_storage_class.constantize.new.get_array("doi_list")
-        end
+        fetch_by("doi_list")&.presence || []
+      end
+
+      def fetch_rejected_doi
+        fetch_by("rejected_doi_list")&.presence || []
       end
 
       # only fetch the sunced orcid id if an orcid identity_table exists?
@@ -40,6 +36,14 @@ module Hyrax
 
       def fetch_all_draft
         @fetch_all_draft ||= ActiveFedora::Base.where("autopopulation_status_tesim:draft")
+      end
+
+      def fetch_by(key)
+        if config.active_record? && Object.const_defined?(:Account)
+          account.settings.dig(key)
+        else
+          config.redis_storage_class.constantize.new.get_array(key)
+        end
       end
 
       private

--- a/app/services/hyrax/autopopulation/redis_storage.rb
+++ b/app/services/hyrax/autopopulation/redis_storage.rb
@@ -39,6 +39,10 @@ module Hyrax
         instance.smembers(key)
       end
 
+      def remove_from_array(key, array_list)
+        instance.srem(key, array_list)
+      end
+
       # A wrapper for Redis mapped_hmset for saving hash
       # hash example
       #  {"hyrax_orcid_settings": {} }

--- a/app/views/hyrax/autopopulation/dashboard/work_fetchers/_hyku_autopopulation_settings_form.html.erb
+++ b/app/views/hyrax/autopopulation/dashboard/work_fetchers/_hyku_autopopulation_settings_form.html.erb
@@ -2,11 +2,12 @@
   <div class="panel-body">
     <div class="form-group">
       <%=f.fields_for :settings do |ff| %>
-        <%= ff.label :orcid_ids_for_autopopulation %><br>
-        <%= ff.text_area :orcid_list, value: current_account.settings.dig("autopopulation", "orcid_list"), class: "form-control", id: "doi_autopopulation_settings" %><br>
+        <%= ff.label t("hyrax.autopopulation.form_doi_label") %><br>
+        <%= ff.text_area :doi_list, value: current_account.settings.dig("autopopulation", "doi_list"), class: "form-control", id: "doi_autopopulation_settings" %><br>
         <br/>
-        <%= ff.label :doi_for_autopopulation %><br>
-        <%= ff.text_area :doi_list, value: current_account.settings.dig("autopopulation", "doi_list"), class: "form-control", id: "orcids_autopopulation_settings" %><br>
+        <%= ff.label t("hyrax.autopopulation.form_orcid_label") %><br>
+        <%= ff.text_area :orcid_list, value: current_account.settings.dig("autopopulation", "orcid_list"), class: "form-control", id: "orcid_autopopulation_settings" %><br>
+     
       <% end %>
     </div>
   </div>

--- a/app/views/hyrax/autopopulation/dashboard/work_fetchers/_hyrax_autopopulation_settings_form.html.erb
+++ b/app/views/hyrax/autopopulation/dashboard/work_fetchers/_hyrax_autopopulation_settings_form.html.erb
@@ -2,11 +2,12 @@
   <div class="panel-body">
     <div class="form-group">
       <%=f.fields_for :settings do |ff| %>
-        <%= ff.label :orcid_ids_for_autopopulation %><br>
-        <%= ff.text_area :orcid_list, value: " ", class: "form-control", id: "doi_autopopulation_settings" %><br>
+        <%= ff.label t("hyrax.autopopulation.form_doi_label") %><br>
+        <%= ff.text_area :doi_list, value: " ", class: "form-control", id: "doi_autopopulation_settings" %><br>
         <br/>
-        <%= ff.label :doi_for_autopopulation %><br>
-        <%= ff.text_area :doi_list, value: " ", class: "form-control", id: "orcids_autopopulation_settings" %><br>
+        <%= ff.label t("hyrax.autopopulation.form_orcid_label") %><br>
+        <%= ff.text_area :orcid_list, value: " ", class: "form-control", id: "orcid_autopopulation_settings" %><br>
+     
       <% end %>
     </div>
   </div>

--- a/app/views/hyrax/autopopulation/dashboard/work_fetchers/_index_table.html.erb
+++ b/app/views/hyrax/autopopulation/dashboard/work_fetchers/_index_table.html.erb
@@ -7,7 +7,7 @@
       <th width="20%">Authors</th>
       <th width="20%">Work Status</th>
       <th width="20%">File Added</th>
-      <th width="20%">Approve</th>
+      <th width="20%">Approve/Reject</th>
       <th width="20%">Actions</th>
     </tr>
   </thead>

--- a/app/views/hyrax/autopopulation/dashboard/work_fetchers/_settings_page.html.erb
+++ b/app/views/hyrax/autopopulation/dashboard/work_fetchers/_settings_page.html.erb
@@ -22,13 +22,18 @@
         <div id="previously-added-id" class="tab-pane">
           <div class="panel panel-default labels">
             <div class="panel-body">
-              <p class="text-primary text-center"> <%= t("hyrax.autopopulation.saved_orcids") %> </p>
+              <p class="text-primary text-center"> <%= saved_orcids.count %> <%= t("hyrax.autopopulation.saved_orcids") %> </p>
               <%= saved_orcids.join(", ") %>
             </div>
 
             <div class="panel-body">
-              <p class="text-primary text-center"> <%= t("hyrax.autopopulation.saved_doi") %> </p>
+              <p class="text-primary text-center"> <%= saved_doi.count %> <%= t("hyrax.autopopulation.saved_doi") %> </p>
               <%= saved_doi.join(", ") %>
+            </div>
+
+            <div class="panel-body">
+              <p class="text-primary text-center"> <%= rejected_doi.count %> <%= t("hyrax.autopopulation.rejected_doi") %> </p>
+              <%= rejected_doi.join(", ") %>
             </div>
           </div>
         </div>

--- a/app/views/hyrax/autopopulation/dashboard/work_fetchers/_work_action_menu.html.erb
+++ b/app/views/hyrax/autopopulation/dashboard/work_fetchers/_work_action_menu.html.erb
@@ -12,7 +12,6 @@
   </button>
 
   <ul role="menu" id="<%= ul_id %>" class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenu_<%= document.id %>">
-
     <% if can? :edit, document.id %>
       <li role="menuitem" tabindex="-1">
         <%= link_to [main_app, :edit, document] do %>
@@ -21,15 +20,17 @@
         <% end %>
       </li>
 
-      <li role="menuitem" tabindex="-1">
-        <%= link_to [main_app, document],
-                    method: :delete,
-                    data: {
-                      confirm: t("hyrax.dashboard.my.action.work_confirmation", application_name: application_name) } do %>
-          <i class="glyphicon glyphicon-trash" aria-hidden="true"></i>
-          <span> <%= t("hyrax.dashboard.my.action.delete_work") %> </span>
-        <% end %>
-      </li>
+      <% if document.autopopulation_status == "approved" %>
+        <li role="menuitem" tabindex="-1">
+          <%= link_to [main_app, document],
+                  method: :delete,
+                  data: {
+                    confirm: t("hyrax.dashboard.my.action.work_confirmation", application_name: application_name) } do %>
+            <i class="glyphicon glyphicon-trash" aria-hidden="true"></i>
+            <span> <%= t("hyrax.dashboard.my.action.delete_work") %> </span>
+          <% end %>
+        </li>
+      <% end %>
     <% end %>
   </ul>
 </div>

--- a/app/views/hyrax/autopopulation/dashboard/work_fetchers/index.html.erb
+++ b/app/views/hyrax/autopopulation/dashboard/work_fetchers/index.html.erb
@@ -39,14 +39,25 @@
                   <%= submit_tag "Approve All", class: "btn btn-primary pull-right" %>  &nbsp;&nbsp;
                 <% end %>
               <% end %>
+              
+              <span> &#160; </span>
 
               <div class="table-responsive">
                 <%= form_tag hyrax_autopopulation.approve_multiple_work_fetchers_path, method: :put do  %>
-                  <%= render "index_table", works: @draft_works %>
-                  <% if @draft_works.present? %> 
-                    <%= submit_tag "Approve Selected", class: "btn btn-primary pull-right" %>
-                  <% end %>
+                   <%= render "index_table", works: @draft_works %>
+
+                    <% if @draft_works.present? %>
+                      <div class="pull-right">
+                        <%= submit_tag "Approve Selected", class: "btn btn-primary", 
+                        data: { confirm: t("hyrax.autopopulation.approve_work_confirmation") } %>
+                        
+                      <%= submit_tag "Reject & delete", formaction: hyrax_autopopulation.reject_multiple_work_fetchers_path,
+                            data: { confirm: t("hyrax.autopopulation.reject_work_confirmation") }, class: "btn btn-danger" %>
+                      </div>
+                    <% end %>
+
                 <% end %>
+              
               </div> 
             </div>
           </div>
@@ -66,7 +77,7 @@
        <div class="panel panel-default labels">
         <div class="panel-body">
           <div class="table-responsive">
-            <%= render "settings_form", account: @account, saved_orcids: @saved_orcids, saved_doi: @saved_doi  %>
+            <%= render "settings_page", account: @account, saved_orcids: @saved_orcids, saved_doi: @saved_doi, rejected_doi: @rejected_doi  %>
           </div>
         <div>
       </div>

--- a/config/locales/hyrax_autopopulation.en.yml
+++ b/config/locales/hyrax_autopopulation.en.yml
@@ -10,11 +10,18 @@ en:
       page_header: Autopopulate Works
       saved_orcids: ORCiD IDs
       saved_doi: DOIs
+      form_doi_label: DOIs for autopopulation
+      form_orcid_label: ORCiD ids for autopopulation
+      rejected_doi: Rejected DOIs from previously imported works
+      reject_work_confirmation: This will save the DOIs to avoid re-import but delete the selected works. Deleting a work from Hyrax is permanent. Click OK to delete this work from Hyrax, or Cancel to cancel this operation
+      approve_work_confirmation: This will change the work from private to public & moved it to the approved_works tab.
       notification:
         subject: autopopulation - Import completed
         body: work autopopulation
         approval_subject: Completed approval autopopulation of works
         approval_body: Autopopulated work approved
+        rejection_subject: Completed rejection of selected autopopulation of works
+        rejection_body: Selected autopopulated work rejected but DOIs saved
       tabs:
         draft: Draft Imports
         approved: Approved Imports
@@ -26,4 +33,5 @@ en:
         success_saving_orcid_doi: The submitted ids were successfully saved
         doi_fetch: Auto-population using DOI in progress, you will a see a notification when completed
         orcid_fetch: Auto-population using ORCID in progress, you will a see a notification when completed
-        approve: Autopopulated works are being approved in the background. 
+        approve: Autopopulated works are being approved in the background.
+        reject: Selected autopopulated works will be deleted & their doi saved in the background.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Hyrax::Autopopulation::Engine.routes.draw do
         post :fetch_with_orcid
         put :approve_multiple
         put :approve_all
+        put :reject_multiple
       end
     end
   end

--- a/lib/hyrax/autopopulation/configuration.rb
+++ b/lib/hyrax/autopopulation/configuration.rb
@@ -35,6 +35,7 @@ module Hyrax
       config_accessor(:create_file_class) { "Hyrax::Autopopulation::CreateFile" }
       config_accessor(:work_fetcher_job) { "Hyrax::Autopopulation::WorkFetcherJob" }
       config_accessor(:approval_job) { "Hyrax::Autopopulation::ApprovalJob" }
+      config_accessor(:rejection_job) { "Hyrax::Autopopulation::RejectionJob" }
       config_accessor(:fetch_and_save_work_metadata) { "Hyrax::Autopopulation::FetchAndSaveWorkMetadata" }
       config_accessor(:app_name) { "hyrax" }
 

--- a/spec/jobs/hyrax/autopopulation/rejection_job_spec.rb
+++ b/spec/jobs/hyrax/autopopulation/rejection_job_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Hyrax::Autopopulation::RejectionJob, type: :job do
+  describe "hyrax rejection" do
+    let(:work) { create(:work, title: ["work"], autopopulation_status: "draft") }
+
+    it "can queue RejectionJob" do
+      expect { described_class.perform_later([work.id]) }.to have_enqueued_job(described_class).with([work.id])
+    end
+  end
+end

--- a/spec/services/hyrax/autopopulation/redis_storage_spec.rb
+++ b/spec/services/hyrax/autopopulation/redis_storage_spec.rb
@@ -11,10 +11,7 @@ RSpec.describe Hyrax::Autopopulation::RedisStorage do
     let(:doi_list) { ["10.36001/ijphm.2018.v9i1.2693"] }
 
     before do
-      redis_storage.orcid_list = orcid_list
-      redis_storage.orcid_list = doi_list
-      redis_storage.save
-
+      allow(redis_storage).to receive(:instance).and_return(redis_instance)
       allow(Redis).to receive(:new).and_return(redis_instance)
       allow(redis_instance).to receive(:sadd).and_return(true)
       allow(redis_instance).to receive(:scard).and_return(orcid_list | doi_list)
@@ -39,6 +36,20 @@ RSpec.describe Hyrax::Autopopulation::RedisStorage do
 
       it "returns doi_list" do
         expect(redis_storage.get_array("doi_list")).to eq doi_list
+      end
+    end
+
+    context "update records" do
+      let(:doi_list) { ["10.36001/ijphm.2018.v9i1.2693", "10.1038/srep15737"] }
+
+      before do
+        allow(redis_instance).to receive(:srem).with("doi_list", [doi_list.first])
+        allow(redis_instance).to receive(:smembers).with("doi_list").and_return([doi_list.last])
+      end
+
+      it "can remove from saved DOIs" do
+        redis_storage.remove_from_array("doi_list", [doi_list.first])
+        expect(redis_storage.get_array("doi_list")).to eq [doi_list.last]
       end
     end
   end


### PR DESCRIPTION
This PR enables Admns to:

- Reject autopopulated works
- When reject the works get deleted but their DOI is saved to **rejected_doi_list**