### PR TITLE
stop creation of doi minting jobs, added more translation text

### DIFF
--- a/app/jobs/hyrax/autopopulation/approval_job.rb
+++ b/app/jobs/hyrax/autopopulation/approval_job.rb
@@ -24,7 +24,9 @@ module Hyrax
       private
 
         def autopopulation_complete_notification(user)
-          user.send_message(user, I18n.t("hyrax.autopopulation.notification.approval_subject"), I18n.t("hyrax.autopopulation.notification.approval_body"))
+          url_path = Hyrax::Autopopulation::Engine.routes.url_helpers.work_fetchers_path(anchor: "approved-import")
+
+          user.send_message(user, I18n.t("hyrax.autopopulation.notification.approval_subject"), I18n.t("hyrax.autopopulation.notification.approval_body", url: url_path))
         end
     end
   end

--- a/app/jobs/hyrax/autopopulation/approval_job.rb
+++ b/app/jobs/hyrax/autopopulation/approval_job.rb
@@ -26,7 +26,8 @@ module Hyrax
         def autopopulation_complete_notification(user)
           url_path = Hyrax::Autopopulation::Engine.routes.url_helpers.work_fetchers_path(anchor: "approved-import")
 
-          user.send_message(user, I18n.t("hyrax.autopopulation.notification.approval_subject"), I18n.t("hyrax.autopopulation.notification.approval_body", url: url_path))
+          user.send_message(user, I18n.t("hyrax.autopopulation.notification.approval_subject"), 
+                            I18n.t("hyrax.autopopulation.notification.approval_body", url: url_path))
         end
     end
   end

--- a/app/services/hyrax/autopopulation/fetch_and_save_work_metadata.rb
+++ b/app/services/hyrax/autopopulation/fetch_and_save_work_metadata.rb
@@ -55,7 +55,9 @@ module Hyrax
         end
 
         def autopopulation_complete_notification
-          user.send_message(user, I18n.t("hyrax.autopopulation.notification.subject"), I18n.t("hyrax.autopopulation.notification.body"))
+          url_path = Hyrax::Autopopulation::Engine.routes.url_helpers.work_fetchers_path(anchor: "draft-import")
+
+          user.send_message(user, I18n.t("hyrax.autopopulation.notification.subject"), I18n.t("hyrax.autopopulation.notification.body", url: url_path))
         end
 
         def config

--- a/app/services/hyrax/autopopulation/fetch_and_save_work_metadata.rb
+++ b/app/services/hyrax/autopopulation/fetch_and_save_work_metadata.rb
@@ -57,7 +57,8 @@ module Hyrax
         def autopopulation_complete_notification
           url_path = Hyrax::Autopopulation::Engine.routes.url_helpers.work_fetchers_path(anchor: "draft-import")
 
-          user.send_message(user, I18n.t("hyrax.autopopulation.notification.subject"), I18n.t("hyrax.autopopulation.notification.body", url: url_path))
+          user.send_message(user, I18n.t("hyrax.autopopulation.notification.subject"), 
+                            I18n.t("hyrax.autopopulation.notification.body", url: url_path))
         end
 
         def config

--- a/app/services/hyrax/autopopulation/record_fetcher.rb
+++ b/app/services/hyrax/autopopulation/record_fetcher.rb
@@ -27,7 +27,8 @@ module Hyrax
       def synced_orcid_identity
         return [] unless config.is_hyrax_orcid_installed
 
-        ::OrcidIdentity.exists? && OrcidIdentity.all.map(&:orcid_id).compact
+        ids = ::OrcidIdentity.exists? && OrcidIdentity.all.map(&:orcid_id).compact
+        ids.presence || []
       end
 
       def fetch_by_ids(work_ids)

--- a/app/services/hyrax/autopopulation/record_persistence.rb
+++ b/app/services/hyrax/autopopulation/record_persistence.rb
@@ -61,7 +61,7 @@ module Hyrax
 
         return unless doi_ids.present?
 
-        save_rejected_work_ids
+        save_rejected_work_ids(doi_ids)
         # so we can do chained method call
         self
       end
@@ -72,7 +72,7 @@ module Hyrax
           Rails.application.config.hyrax_autopopulation
         end
 
-        def save_rejected_work_ids
+        def save_rejected_work_ids(doi_ids)
           if account.present?
             existing_doi = Array.wrap(account.settings["doi_list"])
             remaining_ids = existing_doi - doi_ids
@@ -120,7 +120,6 @@ module Hyrax
           sync_orcid = existing_orcid.blank? ? config.query_class.constantize.new(account).synced_orcid_identity : []
           new_orcid = split_string("orcid_list")&.presence || []
           orcid_ids = remove_url_from_ids(new_orcid)
-
           existing_orcid | orcid_ids | sync_orcid
         end
 

--- a/app/views/hyrax/autopopulation/dashboard/work_fetchers/_hyku_autopopulation_settings_form.html.erb
+++ b/app/views/hyrax/autopopulation/dashboard/work_fetchers/_hyku_autopopulation_settings_form.html.erb
@@ -2,11 +2,19 @@
   <div class="panel-body">
     <div class="form-group">
       <%=f.fields_for :settings do |ff| %>
+
         <%= ff.label t("hyrax.autopopulation.form_doi_label") %><br>
-        <%= ff.text_area :doi_list, value: current_account.settings.dig("autopopulation", "doi_list"), class: "form-control", id: "doi_autopopulation_settings" %><br>
+        <p class="help-block"> <%= t('hyrax.autopopulation.hints.doi') %> </p>
+
+        <%= ff.text_area :doi_list, value: current_account.settings.dig("autopopulation", "doi_list"), 
+         class: "form-control", id: "doi_autopopulation_settings", placeholder:  t('hyrax.autopopulation.hints.doi_input_box') %><br>
         <br/>
+
         <%= ff.label t("hyrax.autopopulation.form_orcid_label") %><br>
-        <%= ff.text_area :orcid_list, value: current_account.settings.dig("autopopulation", "orcid_list"), class: "form-control", id: "orcid_autopopulation_settings" %><br>
+         <p class="help-block"> <%= t('hyrax.autopopulation.hints.orcid') %> </p>
+
+        <%= ff.text_area :orcid_list, value: current_account.settings.dig("autopopulation", "orcid_list"), class: "form-control",
+          id: "orcid_autopopulation_settings", placeholder:  t('hyrax.autopopulation.hints.orcid_input_box') %><br>
      
       <% end %>
     </div>

--- a/app/views/hyrax/autopopulation/dashboard/work_fetchers/_hyrax_autopopulation_settings_form.html.erb
+++ b/app/views/hyrax/autopopulation/dashboard/work_fetchers/_hyrax_autopopulation_settings_form.html.erb
@@ -3,10 +3,15 @@
     <div class="form-group">
       <%=f.fields_for :settings do |ff| %>
         <%= ff.label t("hyrax.autopopulation.form_doi_label") %><br>
-        <%= ff.text_area :doi_list, value: " ", class: "form-control", id: "doi_autopopulation_settings" %><br>
+        <p class="help-block"> <%= t('hyrax.autopopulation.hints.doi') %> </p>
+        <%= ff.text_area :doi_list, value: " ", class: "form-control", 
+         id: "doi_autopopulation_settings", placeholder:  t('hyrax.autopopulation.hints.doi_input_box') %><br>
         <br/>
+
         <%= ff.label t("hyrax.autopopulation.form_orcid_label") %><br>
-        <%= ff.text_area :orcid_list, value: " ", class: "form-control", id: "orcid_autopopulation_settings" %><br>
+        <p class="help-block"> <%= t('hyrax.autopopulation.hints.orcid') %> </p>
+        <%= ff.text_area :orcid_list, value: " ", class: "form-control", 
+         id: "orcid_autopopulation_settings", placeholder:  t('hyrax.autopopulation.hints.orcid_input_box') %><br>
      
       <% end %>
     </div>

--- a/config/locales/hyrax_autopopulation.en.yml
+++ b/config/locales/hyrax_autopopulation.en.yml
@@ -12,26 +12,31 @@ en:
       saved_doi: DOIs
       form_doi_label: DOIs for autopopulation
       form_orcid_label: ORCiD ids for autopopulation
-      rejected_doi: Rejected DOIs from previously imported works
+      rejected_doi: Rejected DOIs from previously autopopulated works
       reject_work_confirmation: This will save the DOIs to avoid re-import but delete the selected works. Deleting a work from Hyrax is permanent. Click OK to delete this work from Hyrax, or Cancel to cancel this operation
       approve_work_confirmation: This will change the work from private to public & moved it to the approved_works tab.
       notification:
         subject: autopopulation - Import completed
-        body: work autopopulation
-        approval_subject: Completed approval autopopulation of works
-        approval_body: Autopopulated work approved
+        body: work autopopulation - <a href= %{url} >see draft works</a>
+        approval_subject: Work autopopulation
+        approval_body: Approval completed - <a href= %{url} >see approved works</a>
         rejection_subject: Completed rejection of selected autopopulation of works
         rejection_body: Selected autopopulated work rejected but DOIs saved
       tabs:
-        draft: Draft Imports
-        approved: Approved Imports
+        draft: Draft Works
+        approved: Approved Works
         settings: Autopopulation Sources
       scan:
-        unpaywall: Scan Unpaywall Using DOI
-        orcid: PerformScan with Orcid
+        unpaywall: Scan with previously added DOI IDs
+        orcid: Scan with previously added ORCiD IDs
       persistence:
-        success_saving_orcid_doi: The submitted ids were successfully saved
-        doi_fetch: Auto-population using DOI in progress, you will a see a notification when completed
-        orcid_fetch: Auto-population using ORCID in progress, you will a see a notification when completed
-        approve: Autopopulated works are being approved in the background.
+        success_saving_orcid_doi: The IDs were added to the list of source IDs
+        doi_fetch: Auto-population using DOI is in progress, you will a see a notification when completed, and works will appear on the Draft Imports tab below, for approval
+        orcid_fetch: Auto-population using ORCID is in progress, you will a see a notification when completed, and works will appear on the Draft Imports tab below, for approval
+        approve: Approved works are being deposited, and will appear in the repository soon.
         reject: Selected autopopulated works will be deleted & their doi saved in the background.
+      hints:
+        orcid: Add multiple ORCIDs by putting each on a new line - examples 0000-0002-9079-593X 0000-0002-0787-9826
+        orcid_input_box:  0000-0002-9079-593X 0000-0002-0787-9826
+        doi: Add multiple DOIs by putting each on a new line - examples 10.1629/uksg.236 10.5678/def
+        doi_input_box: 10.1038/srep15737 10.1111/1559-8918.2019.01273

--- a/lib/hyrax/autopopulation/engine.rb
+++ b/lib/hyrax/autopopulation/engine.rb
@@ -22,6 +22,10 @@ module Hyrax
       # Prepend our views so they have precedence
       config.after_initialize do
         ActionController::Base.prepend_view_path(paths["app/views"].existent)
+        
+        if Object.const_defined? "Hyrax::Actors::DOIActor"
+          ::Hyrax::Actors::DOIActor.prepend(Hyrax::Autopopulation::DoiActorOverride)
+        end
       end
 
       # Allows us to access the configuration object from Rails application config
@@ -48,6 +52,7 @@ module Hyrax
           ::Hyrax::BasicMetadata.include(Hyrax::Autopopulation::DoiProperty)
           ::Hyrax::SolrDocumentBehavior.include(Hyrax::Autopopulation::SolrDocumentBehavior)
         end
+
       end
 
       # Use #to_prepare because it reloads where after_initialize only runs once

--- a/lib/hyrax/autopopulation/engine.rb
+++ b/lib/hyrax/autopopulation/engine.rb
@@ -52,7 +52,6 @@ module Hyrax
           ::Hyrax::BasicMetadata.include(Hyrax::Autopopulation::DoiProperty)
           ::Hyrax::SolrDocumentBehavior.include(Hyrax::Autopopulation::SolrDocumentBehavior)
         end
-
       end
 
       # Use #to_prepare because it reloads where after_initialize only runs once


### PR DESCRIPTION
- Stop creation of the jobs that mint doi when creating new works from autopopulation
- Added more translation to cover placeholder and changes to some existing translations
- Ensure doi and orcid are saved correctly in accounts table