### PR TITLE
move including modules into hyku-addons away from engine.rb into the files in hyku_addons directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,26 @@ Or install it yourself as:
 $ gem install hyrax-autopopulation
 ```
 
+For Hyrax engine.rb does the include but if you are using Hyku or HykuAddons then include the module below into the files shown in order
+to add the property :autopopulation_status:
+````ruby
+ include Hyrax::Autopopulation::AutopopulationProperty
+````
+
+into the following files:
+
+https://github.com/ubiquitypress/hyku_addons/blob/main/app/models/concerns/hyku_addons/work_base.rb
+
+https://github.com/ubiquitypress/hyku_addons/blob/main/app/models/concerns/hyku_addons/schema/work_base.rb
+
+
+Also for Hyku & HykuAddons users only include:
+````ruby
+  include Hyrax::Autopopulation::SolrDocumentBehavior
+````
+
+https://github.com/ubiquitypress/hyku_addons/blob/main/app/models/concerns/hyku_addons/solr_document_behavior.rb
+
 ## Contributing
 Contribution directions go here.
 

--- a/lib/hyrax/autopopulation/engine.rb
+++ b/lib/hyrax/autopopulation/engine.rb
@@ -48,15 +48,11 @@ module Hyrax
       def self.dynamically_include_mixins
         ::Bolognese::Metadata.prepend ::Bolognese::Writers::HyraxWorkActorAttributes
 
-        if config.hyrax_autopopulation.app_name == "hyku_addons"
-          ::HykuAddons::WorkBase.prepend(Hyrax::Autopopulation::AutopopulationProperty)
-          ::HykuAddons::Schema::WorkBase.prepend(Hyrax::Autopopulation::AutopopulationProperty)
-          ::HykuAddons::SolrDocumentBehavior.prepend(Hyrax::Autopopulation::SolrDocumentBehavior)
-        else
+        if config.hyrax_autopopulation.app_name != "hyku_addons"
           ::Hyrax::BasicMetadata.include(Hyrax::Autopopulation::AutopopulationProperty)
           ::Hyrax::BasicMetadata.include(Hyrax::Autopopulation::DoiProperty)
           ::Hyrax::SolrDocumentBehavior.include(Hyrax::Autopopulation::SolrDocumentBehavior)
-        end       
+        end
       end
 
       # Use #to_prepare because it reloads where after_initialize only runs once


### PR DESCRIPTION

For whatever reason every attempt to use **include** or **prepend** or **module_eval** from the engine.rb file failed in one way or the other. So I basically remove them and added them directly to the hyku_addons gem files.