### PR TITLE
save ids of works that are not open access to the rejected_doi_list when creating works using orcid

### DIFF
--- a/app/controllers/hyrax/autopopulation/dashboard/work_fetchers_controller.rb
+++ b/app/controllers/hyrax/autopopulation/dashboard/work_fetchers_controller.rb
@@ -53,7 +53,7 @@ module Hyrax
           config_object.work_fetcher_job.constantize.perform_later(args)
 
           flash[:notice] = I18n.t("hyrax.autopopulation.persistence.doi_fetch")
-          redirect_to hyrax_autopopulation.work_fetchers_path(anchor: "draft-import")
+          redirect_to hyrax_autopopulation.work_fetchers_path(anchor: "fetched-import")
         end
 
         # POST request
@@ -63,7 +63,7 @@ module Hyrax
           config_object.work_fetcher_job.constantize.perform_later(args)
 
           flash[:notice] = I18n.t("hyrax.autopopulation.persistence.orcid_fetch")
-          redirect_to hyrax_autopopulation.work_fetchers_path(anchor: "draft-import")
+          redirect_to hyrax_autopopulation.work_fetchers_path(anchor: "fetched-import")
         end
 
         # PUT request
@@ -144,10 +144,10 @@ module Hyrax
           end
 
           def redirect_when_feature_is_off
-            unless Flipflop.enabled?(:hyrax_autopopulation)
-              flash[:notice] =  I18n.t("hyrax.autopopulation.feature_flip_msg")
-              redirect_to main_app.root_path
-            end
+            return if Flipflop.enabled?(:hyrax_autopopulation)
+
+            flash[:notice] = I18n.t("hyrax.autopopulation.feature_flip_msg")
+            redirect_to main_app.root_path
           end
       end
     end

--- a/app/jobs/hyrax/autopopulation/remove_non_open_access_doi_job.rb
+++ b/app/jobs/hyrax/autopopulation/remove_non_open_access_doi_job.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module Autopopulation
+    class RemoveNonOpenAccessDoiJob < ApplicationJob
+      def perform(account, doi_list)
+        config = Rails.application.config.hyrax_autopopulation
+        klass = config.persistence_class.constantize.new(account: account, rejected_doi: doi_list)
+        klass.save_rejected_ids
+      end
+    end
+  end
+end

--- a/app/services/hyrax/autopopulation/fetch_and_save_work_metadata.rb
+++ b/app/services/hyrax/autopopulation/fetch_and_save_work_metadata.rb
@@ -5,12 +5,13 @@ module Hyrax
     class FetchAndSaveWorkMetadata
       include Hyrax::Autopopulation::ParseIdentifier
 
-      attr_accessor :user, :account, :doi_list
+      attr_accessor :user, :account, :doi_list, :rejected_doi_list
 
       def initialize(user:, doi_list:, account: nil)
         @user = user
         @account = account
         @doi_list = doi_list
+        @rejected_doi_list = []
       end
 
       def save
@@ -21,12 +22,27 @@ module Hyrax
         end
 
         autopopulation_complete_notification
+        queue_removal_of_non_open_access_doi
       end
 
       private
 
+        def push_into_reject_doi_list(data)
+          return if data["is_oa"]
+
+          @rejected_doi_list << data["doi"]
+        end
+
+        def queue_removal_of_non_open_access_doi
+          return if rejected_doi_list.empty?
+
+          # Move non open access doi into the rejected_doi_list
+          config.remove_non_open_access_doi_job.constantize.perform_later(account, rejected_doi_list)
+        end
+
         def fetch_and_create_work_with_doi(doi)
           unpaywall_data = config.unpaywall_client.constantize.new(doi).data
+          push_into_reject_doi_list(unpaywall_data)
 
           return unless unpaywall_data["is_oa"]&.present?
 
@@ -34,16 +50,18 @@ module Hyrax
 
           # adding the file url since crossref does not have it
           work_data[:unpaywall_pdf_url] = unpaywall_data.dig("best_oa_location", "url_for_pdf")
-
           config.create_work_class.constantize.new(work_data, user, account).save
         end
 
         def check_for_work_doi(doi)
           new_doi = slice_out_id_from_url(doi)
 
-          return unless new_doi.present?
+          # with escaping doi like 10.1016/S1296-2074(03)00005-0 are bad request
+          doi_with_escaped_special_characters = RSolr.solr_escape(new_doi.downcase)
 
-          ActiveFedora::SolrService.count("doi_ssi: #{new_doi}", rows: 1)
+          return unless doi_with_escaped_special_characters.present?
+
+          ActiveFedora::SolrService.count("doi_ssi: #{doi_with_escaped_special_characters}", rows: 1)
         end
 
         def fetch_crossref_work_data(doi)
@@ -57,7 +75,7 @@ module Hyrax
         def autopopulation_complete_notification
           url_path = Hyrax::Autopopulation::Engine.routes.url_helpers.work_fetchers_path(anchor: "draft-import")
 
-          user.send_message(user, I18n.t("hyrax.autopopulation.notification.subject"), 
+          user.send_message(user, I18n.t("hyrax.autopopulation.notification.subject"),
                             I18n.t("hyrax.autopopulation.notification.body", url: url_path))
         end
 

--- a/app/views/hyrax/autopopulation/dashboard/work_fetchers/_index_table.html.erb
+++ b/app/views/hyrax/autopopulation/dashboard/work_fetchers/_index_table.html.erb
@@ -3,7 +3,7 @@
   <thead>
     <tr>
       <th width="40%">Work Title</th>
-      <th width="20%">Date Imported</th>
+      <th width="20%">Date Fetched</th>
       <th width="20%">Authors</th>
       <th width="20%">Work Status</th>
       <th width="20%">File Added</th>

--- a/app/views/hyrax/autopopulation/dashboard/work_fetchers/index.html.erb
+++ b/app/views/hyrax/autopopulation/dashboard/work_fetchers/index.html.erb
@@ -23,7 +23,7 @@
           <a href="#autopopulation-settings" role="tab" data-toggle="tab"><%= t("hyrax.autopopulation.tabs.settings") %></a>
         </li>
         <li>
-          <a href="#draft-import" role="tab" data-toggle="tab"><%= t("hyrax.autopopulation.tabs.draft") %></a>
+          <a href="#fetched-import" role="tab" data-toggle="tab"><%= t("hyrax.autopopulation.tabs.draft") %></a>
         </li>
         <li>
           <a href="#approved-import" role="tab" data-toggle="tab"><%= t("hyrax.autopopulation.tabs.approved") %></a>
@@ -31,7 +31,7 @@
       </ul>
 
       <div class="tab-content">
-        <div id="draft-import" class="tab-pane">
+        <div id="fetched-import" class="tab-pane">
           <div class="panel panel-default labels">
             <div class="panel-body">
               <%= form_tag hyrax_autopopulation.approve_all_work_fetchers_path, method: :put do  %>

--- a/config/locales/hyrax_autopopulation.en.yml
+++ b/config/locales/hyrax_autopopulation.en.yml
@@ -10,8 +10,8 @@ en:
       page_header: Autopopulate Works
       saved_orcids: ORCiD IDs
       saved_doi: DOIs
-      form_doi_label: DOIs for autopopulation
-      form_orcid_label: ORCiD ids for autopopulation
+      form_doi_label: DOIs
+      form_orcid_label: ORCIDs
       rejected_doi: Rejected DOIs from previously autopopulated works
       reject_work_confirmation: This will save the DOIs to avoid re-import but delete the selected works. Deleting a work from Hyrax is permanent. Click OK to delete this work from Hyrax, or Cancel to cancel this operation
       approve_work_confirmation: This will change the work from private to public & moved it to the approved_works tab.
@@ -24,12 +24,13 @@ en:
         rejection_subject: Completed rejection of selected autopopulation of works
         rejection_body: Selected autopopulated work rejected but DOIs saved
       tabs:
-        draft: Draft Works
+        draft: Fetched Works
         approved: Approved Works
         settings: Autopopulation Sources
+        ids: IDS
       scan:
-        unpaywall: Scan with previously added DOI IDs
-        orcid: Scan with previously added ORCiD IDs
+        unpaywall: Scan DOIs
+        orcid: Scan ORCIDs
       persistence:
         success_saving_orcid_doi: The IDs were added to the list of source IDs
         doi_fetch: Auto-population using DOI is in progress, you will a see a notification when completed, and works will appear on the Draft Imports tab below, for approval

--- a/lib/hyrax/autopopulation/configuration.rb
+++ b/lib/hyrax/autopopulation/configuration.rb
@@ -38,6 +38,7 @@ module Hyrax
       config_accessor(:rejection_job) { "Hyrax::Autopopulation::RejectionJob" }
       config_accessor(:fetch_and_save_work_metadata) { "Hyrax::Autopopulation::FetchAndSaveWorkMetadata" }
       config_accessor(:app_name) { "hyrax" }
+      config_accessor(:remove_non_open_access_doi_job) { "Hyrax::Autopopulation::RemoveNonOpenAccessDoiJob" }
 
       def active_record?
         storage_type == "activerecord"

--- a/spec/factories/accounts.rb
+++ b/spec/factories/accounts.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+FactoryBot.define do
+  factory :account do
+    sequence(:cname) { |n| "repor#{n}.hyku.docker" }
+  end
+end

--- a/spec/jobs/hyrax/autopopulation/remove_non_open_access_doi_job_spec.rb
+++ b/spec/jobs/hyrax/autopopulation/remove_non_open_access_doi_job_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Hyrax::Autopopulation::RemoveNonOpenAccessDoiJob, type: :job do
+  describe "hyrax non open access doi" do
+    let(:account) { build_stubbed(:account, cname: "repo") }
+    let(:dois) { ["10.1016/j.crvasa.2015.05.007", "10.36001/ijphm.2018.v9i1.2693"] }
+
+    before do
+      # use by activejob to find the account
+      allow(Account).to receive(:find).with(account.id.to_s).and_return(account)
+    end
+
+    it "can queue non openacess doi for Rejection" do
+      expect { described_class.perform_later([account, dois]) }.to have_enqueued_job(described_class).with([account, dois])
+    end
+  end
+end

--- a/spec/services/hyrax/autopopulation/record_persistence_spec.rb
+++ b/spec/services/hyrax/autopopulation/record_persistence_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Hyrax::Autopopulation::RecordPersistence do
+  context "clean strings" do
+    let(:bad_string_with_escape_characters) { "\"10.1629/uksg.236\", \"10.1371/journal.pone.0261098\", \"10.1087/20120404\", \"10.5334/joc.210\", \"10.5334/joc.209\"" }
+    let(:cleaned_without_escape_charaters) { ["10.1629/uksg.236", "10.1371/journal.pone.0261098", "10.1087/20120404", "10.5334/joc.210", "10.5334/joc.209"] }
+
+    let(:string_with_new_line_and_space) { "10.1038/srep15737 \n 10.1038/nature12373 , 10.1016/j.crvasa.2015.05.008 10.1111/1559-8918.2019.01273" }
+    let(:cleaned_string_with_new_line_and_space) { ["10.1038/srep15737", "10.1038/nature12373", "10.1016/j.crvasa.2015.05.008", "10.1111/1559-8918.2019.01273"] }
+    let(:data) do
+      { "settings" => { "doi_list" => bad_string_with_escape_characters } }
+    end
+
+    let(:account) { instance_double(Account, cname: "repo") }
+    let(:subject) { described_class.new(data: data, account: account) }
+
+    before do
+      allow(AccountElevator).to receive(:switch!).and_return(true)
+    end
+    it "can remove escape characters" do
+      expect(subject.send(:split_string, "doi_list")).to eq cleaned_without_escape_charaters
+    end
+
+    it "can split on new line and space" do
+      data["settings"]["doi_list"] = string_with_new_line_and_space
+      expect(subject.send(:split_string, "doi_list")).to eq cleaned_string_with_new_line_and_space
+    end
+  end
+end


### PR DESCRIPTION
Also contains code using **RSolr.escape** to escape special characters eg **( )** in doi before queryng against Solr to avoid Solr Bad Request error.